### PR TITLE
[P1] Add interface contracts and base models

### DIFF
--- a/src/vindicta_core/__init__.py
+++ b/src/vindicta_core/__init__.py
@@ -3,6 +3,39 @@
 Constitution XVI compliant: Async-ready configuration.
 """
 
+from vindicta_core.interfaces import (
+    BaseDiceEngine,
+    BaseGasTank,
+    DiceEngineProtocol,
+    GasTankProtocol,
+    OracleProtocol,
+)
+from vindicta_core.models import (
+    CostEstimate,
+    DiceResult,
+    EntropyProof,
+    GasTankState,
+    IdentifiableModel,
+    TimestampedModel,
+    VindictaModel,
+)
 from vindicta_core.settings import Settings
 
-__all__ = ["Settings"]
+__all__ = [
+    # Settings
+    "Settings",
+    # Models
+    "VindictaModel",
+    "TimestampedModel",
+    "IdentifiableModel",
+    "EntropyProof",
+    "DiceResult",
+    "GasTankState",
+    "CostEstimate",
+    # Interfaces
+    "DiceEngineProtocol",
+    "GasTankProtocol",
+    "OracleProtocol",
+    "BaseDiceEngine",
+    "BaseGasTank",
+]

--- a/src/vindicta_core/interfaces.py
+++ b/src/vindicta_core/interfaces.py
@@ -1,0 +1,112 @@
+"""Interface contracts for Vindicta Platform services.
+
+Constitution Compliance:
+- III. Spec-Driven: Interfaces define contracts before implementation
+- XVI. Async-First: All interfaces use async signatures
+"""
+
+from abc import ABC, abstractmethod
+from typing import Protocol
+
+from vindicta_core.models import CostEstimate, DiceResult, GasTankState
+
+
+class DiceEngineProtocol(Protocol):
+    """Protocol for dice rolling services per Constitution VI.
+    
+    All implementations MUST:
+    - Use CSPRNG for randomness
+    - Generate EntropyProof for every roll
+    - Apply rejection sampling to eliminate modulo bias
+    """
+    
+    async def roll(self, sides: int, count: int = 1) -> list[DiceResult]:
+        """Roll dice with cryptographic randomness."""
+        ...
+    
+    async def roll_d6(self, count: int = 1) -> list[DiceResult]:
+        """Roll standard d6 dice (Warhammer 40K standard)."""
+        ...
+
+
+class GasTankProtocol(Protocol):
+    """Protocol for Gas Tank cost control per Constitution II.
+    
+    All cost-incurring features MUST:
+    - Estimate cost before execution
+    - Check Gas Tank balance
+    - STOP immediately when tank is empty
+    """
+    
+    async def get_state(self) -> GasTankState:
+        """Get current Gas Tank state."""
+        ...
+    
+    async def estimate_cost(self, feature: str, **kwargs) -> CostEstimate:
+        """Estimate cost before igniting a feature."""
+        ...
+    
+    async def consume(self, amount_usd: float, feature: str) -> bool:
+        """Consume gas for a feature. Returns False if insufficient."""
+        ...
+
+
+class OracleProtocol(Protocol):
+    """Protocol for AI Oracle services per Constitution II.
+    
+    MUST use Gemini models via Vertex AI or AI Studio.
+    """
+    
+    async def query(self, prompt: str, context: dict | None = None) -> str:
+        """Query the Oracle with a prompt."""
+        ...
+    
+    async def estimate_tokens(self, prompt: str) -> int:
+        """Estimate token count for a prompt."""
+        ...
+
+
+# Abstract base classes for implementations
+
+class BaseDiceEngine(ABC):
+    """Abstract base for dice engine implementations."""
+    
+    @abstractmethod
+    async def roll(self, sides: int, count: int = 1) -> list[DiceResult]:
+        """Roll dice with cryptographic randomness."""
+        pass
+    
+    async def roll_d6(self, count: int = 1) -> list[DiceResult]:
+        """Roll standard d6."""
+        return await self.roll(6, count)
+    
+    async def roll_d3(self, count: int = 1) -> list[DiceResult]:
+        """Roll d3 (half d6, rounded up)."""
+        d6_results = await self.roll(6, count)
+        return [
+            DiceResult(
+                value=(r.value + 1) // 2,
+                sides=3,
+                proof=r.proof
+            )
+            for r in d6_results
+        ]
+
+
+class BaseGasTank(ABC):
+    """Abstract base for Gas Tank implementations."""
+    
+    @abstractmethod
+    async def get_state(self) -> GasTankState:
+        """Get current state."""
+        pass
+    
+    @abstractmethod
+    async def estimate_cost(self, feature: str, **kwargs) -> CostEstimate:
+        """Estimate feature cost."""
+        pass
+    
+    @abstractmethod
+    async def consume(self, amount_usd: float, feature: str) -> bool:
+        """Consume gas. Returns False if empty."""
+        pass

--- a/src/vindicta_core/models.py
+++ b/src/vindicta_core/models.py
@@ -1,0 +1,86 @@
+"""Base models for Vindicta Platform.
+
+Constitution Compliance:
+- VII. Mechanical Fidelity: Models support 40K 10th Ed mechanics
+- XVI. Async-First: All models are serialization-ready
+"""
+
+from datetime import datetime
+from typing import Literal
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, Field
+
+
+class VindictaModel(BaseModel):
+    """Base model for all Vindicta entities.
+    
+    Provides common fields and serialization behavior.
+    """
+    
+    class Config:
+        frozen = False
+        populate_by_name = True
+        json_encoders = {
+            UUID: str,
+            datetime: lambda v: v.isoformat(),
+        }
+
+
+class TimestampedModel(VindictaModel):
+    """Model with automatic timestamps."""
+    
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime | None = None
+
+
+class IdentifiableModel(TimestampedModel):
+    """Model with UUID identifier."""
+    
+    id: UUID = Field(default_factory=uuid4)
+
+
+# Dice & Randomness (Constitution VI)
+
+class EntropyProof(VindictaModel):
+    """Proof of entropy for dice rolls per Constitution VI.
+    
+    Every mechanical event MUST generate a traceable EntropyProof.
+    """
+    
+    seed_hash: str = Field(..., description="SHA-256 of the entropy seed")
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    algorithm: Literal["csprng", "rejection_sampling"] = "csprng"
+    audit_trail_id: UUID = Field(default_factory=uuid4)
+
+
+class DiceResult(VindictaModel):
+    """Result of a dice roll with entropy proof."""
+    
+    value: int = Field(..., ge=1, description="Rolled value")
+    sides: int = Field(..., ge=2, description="Number of sides on die")
+    proof: EntropyProof
+
+
+# Gas Tank (Constitution II)
+
+class GasTankState(VindictaModel):
+    """Current state of the Gas Tank per Constitution II."""
+    
+    balance_usd: float = Field(0.0, ge=0.0)
+    limit_usd: float = Field(0.0, ge=0.0, description="Max allowed spend")
+    is_active: bool = True
+    
+    @property
+    def is_empty(self) -> bool:
+        """Gas Tank is empty when balance reaches zero."""
+        return self.balance_usd <= 0.0
+
+
+class CostEstimate(VindictaModel):
+    """Cost estimate before igniting a Gas Tank feature."""
+    
+    estimated_usd: float = Field(..., ge=0.0)
+    feature_name: str
+    can_proceed: bool = False
+    reason: str | None = None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,98 @@
+"""Tests for Vindicta Core models - Constitution XV compliant."""
+
+import pytest
+from uuid import UUID
+
+from vindicta_core.models import (
+    CostEstimate,
+    DiceResult,
+    EntropyProof,
+    GasTankState,
+    IdentifiableModel,
+    VindictaModel,
+)
+
+
+class TestEntropyProof:
+    """Tests for EntropyProof per Constitution VI."""
+    
+    def test_creates_with_required_fields(self):
+        """EntropyProof requires seed_hash."""
+        proof = EntropyProof(seed_hash="abc123")
+        assert proof.seed_hash == "abc123"
+        assert proof.algorithm == "csprng"
+        assert isinstance(proof.audit_trail_id, UUID)
+    
+    def test_algorithm_options(self):
+        """Supports csprng and rejection_sampling."""
+        proof = EntropyProof(
+            seed_hash="def456",
+            algorithm="rejection_sampling"
+        )
+        assert proof.algorithm == "rejection_sampling"
+
+
+class TestDiceResult:
+    """Tests for DiceResult per Constitution VI."""
+    
+    def test_creates_with_proof(self):
+        """DiceResult must include EntropyProof."""
+        proof = EntropyProof(seed_hash="test")
+        result = DiceResult(value=4, sides=6, proof=proof)
+        
+        assert result.value == 4
+        assert result.sides == 6
+        assert result.proof.seed_hash == "test"
+    
+    def test_value_must_be_positive(self):
+        """Dice value must be >= 1."""
+        proof = EntropyProof(seed_hash="test")
+        with pytest.raises(ValueError):
+            DiceResult(value=0, sides=6, proof=proof)
+
+
+class TestGasTankState:
+    """Tests for GasTankState per Constitution II."""
+    
+    def test_defaults_to_zero_balance(self):
+        """Default balance is 0 (free tier)."""
+        state = GasTankState()
+        assert state.balance_usd == 0.0
+        assert state.is_empty is True
+    
+    def test_is_empty_when_zero(self):
+        """Tank is empty at zero balance."""
+        state = GasTankState(balance_usd=0.0)
+        assert state.is_empty is True
+        
+    def test_not_empty_with_balance(self):
+        """Tank not empty with positive balance."""
+        state = GasTankState(balance_usd=1.0)
+        assert state.is_empty is False
+
+
+class TestCostEstimate:
+    """Tests for CostEstimate per Constitution II."""
+    
+    def test_requires_feature_name(self):
+        """Estimate must specify feature."""
+        estimate = CostEstimate(
+            estimated_usd=0.01,
+            feature_name="oracle_query"
+        )
+        assert estimate.feature_name == "oracle_query"
+        assert estimate.can_proceed is False
+
+
+class TestIdentifiableModel:
+    """Tests for IdentifiableModel."""
+    
+    def test_auto_generates_uuid(self):
+        """ID is auto-generated."""
+        model = IdentifiableModel()
+        assert isinstance(model.id, UUID)
+    
+    def test_has_timestamps(self):
+        """Inherits timestamp fields."""
+        model = IdentifiableModel()
+        assert model.created_at is not None


### PR DESCRIPTION
## Summary
Add base models and interface protocols for platform services.

## Changes
- models.py: VindictaModel, EntropyProof, DiceResult, GasTankState
- interfaces.py: DiceEngineProtocol, GasTankProtocol, OracleProtocol
- 10 new tests

## Constitution
- [x] II. Gas Tank
- [x] VI. Statistical
- [x] XVI. Async-First

Signed-off-by: Gemini Agent