### PR TITLE
feat: Add SpecKit bundles for 3 Vindicta-Core features

### DIFF
--- a/.specify/specs/038-domain-validators/plan.md
+++ b/.specify/specs/038-domain-validators/plan.md
@@ -1,0 +1,25 @@
+# Implementation Plan: Domain Model Validators
+
+**Branch**: `038-domain-validators` | **Date**: 2026-02-06 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Comprehensive validation layer for domain models. Checks required fields, type constraints, and provides detailed errors.
+
+## Technical Context
+
+**Language/Version**: Python 3.11  
+**Primary Dependencies**: Pydantic  
+**Storage**: N/A  
+**Testing**: pytest  
+**Target Platform**: Vindicta-Core  
+**Project Type**: Backend library  
+
+## Project Structure
+
+```text
+Vindicta-Core/src/
+└── validation/
+    ├── validators.py        # [NEW] Validator implementations
+    └── errors.py            # [NEW] Error models
+```

--- a/.specify/specs/038-domain-validators/spec.md
+++ b/.specify/specs/038-domain-validators/spec.md
@@ -1,0 +1,33 @@
+# Feature Specification: Domain Model Validators
+
+**Feature Branch**: `038-domain-validators`  
+**Created**: 2026-02-06  
+**Status**: Draft  
+**Target**: Week 2 | **Repository**: Vindicta-Core
+
+## User Scenarios & Testing
+
+### User Story 1 - Validate Domain Models (Priority: P1)
+
+System validates domain model instances.
+
+**Acceptance Scenarios**:
+1. **Given** valid model, **When** validated, **Then** passes
+2. **Given** invalid model, **When** validated, **Then** errors returned
+
+---
+
+## Requirements
+
+### Functional Requirements
+- **FR-001**: Validators MUST check required fields
+- **FR-002**: Validators MUST check type constraints
+- **FR-003**: Validators MUST provide detailed error messages
+
+### Key Entities
+- **ValidationResult**: valid, errors[]
+- **FieldError**: field, message, constraint
+
+## Success Criteria
+- **SC-001**: Validation in <10ms
+- **SC-002**: 100% coverage of model constraints

--- a/.specify/specs/038-domain-validators/tasks.md
+++ b/.specify/specs/038-domain-validators/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: Domain Model Validators
+
+**Input**: specs/038-domain-validators/ | **Prerequisites**: spec.md, plan.md
+
+## Phase 1: Setup
+
+- [ ] T001 Create `src/validation/` directory
+
+---
+
+## Phase 2: Foundational
+
+- [ ] T002 Define ValidationResult model
+- [ ] T003 [P] Define FieldError model
+
+---
+
+## Phase 3: User Story 1 - Validate Domain Models (P1) 🎯 MVP
+
+- [ ] T004 [US1] Implement base Validator class
+- [ ] T005 [US1] Add required field validation
+- [ ] T006 [US1] Add type constraint validation
+- [ ] T007 [US1] Generate detailed error messages
+
+---
+
+## Phase 4: Polish
+
+- [ ] T008 [P] Optimize for <10ms validation
+- [ ] T009 [P] Write validation tests

--- a/.specify/specs/039-type-registry/plan.md
+++ b/.specify/specs/039-type-registry/plan.md
@@ -1,0 +1,25 @@
+# Implementation Plan: Shared Type Registry
+
+**Branch**: `039-type-registry` | **Date**: 2026-02-06 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Centralized type definitions for cross-service consistency. Supports versioning and ensures platform-wide type compatibility.
+
+## Technical Context
+
+**Language/Version**: Python 3.11  
+**Primary Dependencies**: Pydantic  
+**Storage**: N/A  
+**Testing**: pytest  
+**Target Platform**: Vindicta-Core  
+**Project Type**: Backend library  
+
+## Project Structure
+
+```text
+Vindicta-Core/src/
+└── registry/
+    ├── types.py             # [NEW] Type definitions
+    └── registry.py          # [NEW] Registry manager
+```

--- a/.specify/specs/039-type-registry/spec.md
+++ b/.specify/specs/039-type-registry/spec.md
@@ -1,0 +1,33 @@
+# Feature Specification: Shared Type Registry
+
+**Feature Branch**: `039-type-registry`  
+**Created**: 2026-02-06  
+**Status**: Draft  
+**Target**: Week 3 | **Repository**: Vindicta-Core
+
+## User Scenarios & Testing
+
+### User Story 1 - Register Shared Types (Priority: P1)
+
+System provides centralized type definitions.
+
+**Acceptance Scenarios**:
+1. **Given** type definition, **When** registered, **Then** available platform-wide
+2. **Given** registered type, **When** imported, **Then** consistent across services
+
+---
+
+## Requirements
+
+### Functional Requirements
+- **FR-001**: Registry MUST define all shared types
+- **FR-002**: Registry MUST ensure type consistency
+- **FR-003**: Registry MUST support versioning
+
+### Key Entities
+- **TypeDefinition**: name, schema, version
+- **TypeRegistry**: types[], get(), register()
+
+## Success Criteria
+- **SC-001**: Zero type conflicts
+- **SC-002**: 100% cross-service compatibility

--- a/.specify/specs/039-type-registry/tasks.md
+++ b/.specify/specs/039-type-registry/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: Shared Type Registry
+
+**Input**: specs/039-type-registry/ | **Prerequisites**: spec.md, plan.md
+
+## Phase 1: Setup
+
+- [ ] T001 Create `src/registry/` directory
+
+---
+
+## Phase 2: Foundational
+
+- [ ] T002 Define TypeDefinition model
+- [ ] T003 [P] Create TypeRegistry singleton
+
+---
+
+## Phase 3: User Story 1 - Register Shared Types (P1) 🎯 MVP
+
+- [ ] T004 [US1] Implement `register()` method
+- [ ] T005 [US1] Implement `get()` method
+- [ ] T006 [US1] Add version tracking
+- [ ] T007 [US1] Register core platform types
+
+---
+
+## Phase 4: Polish
+
+- [ ] T008 [P] Add type conflict detection
+- [ ] T009 [P] Write registry tests

--- a/.specify/specs/040-event-sourcing/plan.md
+++ b/.specify/specs/040-event-sourcing/plan.md
@@ -1,0 +1,26 @@
+# Implementation Plan: Event Sourcing Primitives
+
+**Branch**: `040-event-sourcing` | **Date**: 2026-02-06 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Event sourcing foundation with immutable event storage and replay. Supports state reconstruction from event streams.
+
+## Technical Context
+
+**Language/Version**: Python 3.11  
+**Primary Dependencies**: Pydantic, SQLite  
+**Storage**: SQLite (append-only)  
+**Testing**: pytest  
+**Target Platform**: Vindicta-Core  
+**Project Type**: Backend library  
+
+## Project Structure
+
+```text
+Vindicta-Core/src/
+└── events/
+    ├── store.py             # [NEW] Event store
+    ├── models.py            # [NEW] Event models
+    └── replay.py            # [NEW] Replay logic
+```

--- a/.specify/specs/040-event-sourcing/spec.md
+++ b/.specify/specs/040-event-sourcing/spec.md
@@ -1,0 +1,33 @@
+# Feature Specification: Event Sourcing Primitives
+
+**Feature Branch**: `040-event-sourcing`  
+**Created**: 2026-02-06  
+**Status**: Draft  
+**Target**: Week 4 | **Repository**: Vindicta-Core
+
+## User Scenarios & Testing
+
+### User Story 1 - Append Events (Priority: P1)
+
+System stores domain events immutably.
+
+**Acceptance Scenarios**:
+1. **Given** domain event, **When** appended, **Then** stored in log
+2. **Given** event log, **When** replayed, **Then** state reconstructed
+
+---
+
+## Requirements
+
+### Functional Requirements
+- **FR-001**: Store MUST append events immutably
+- **FR-002**: Store MUST support replay from any point
+- **FR-003**: Store MUST track event ordering
+
+### Key Entities
+- **DomainEvent**: type, payload, timestamp, aggregateId
+- **EventStore**: append(), replay(), getStream()
+
+## Success Criteria
+- **SC-001**: Append in <10ms
+- **SC-002**: Replay 1000 events in <500ms

--- a/.specify/specs/040-event-sourcing/tasks.md
+++ b/.specify/specs/040-event-sourcing/tasks.md
@@ -1,0 +1,31 @@
+# Tasks: Event Sourcing Primitives
+
+**Input**: specs/040-event-sourcing/ | **Prerequisites**: spec.md, plan.md
+
+## Phase 1: Setup
+
+- [ ] T001 Create `src/events/` directory
+- [ ] T002 [P] Create SQLite schema
+
+---
+
+## Phase 2: Foundational
+
+- [ ] T003 Define DomainEvent model
+- [ ] T004 [P] Initialize EventStore class
+
+---
+
+## Phase 3: User Story 1 - Append Events (P1) 🎯 MVP
+
+- [ ] T005 [US1] Implement `append()` method
+- [ ] T006 [US1] Implement `getStream()` method
+- [ ] T007 [US1] Implement `replay()` method
+- [ ] T008 [US1] Track event ordering
+
+---
+
+## Phase 4: Polish
+
+- [ ] T009 [P] Optimize replay for <500ms
+- [ ] T010 [P] Write event sourcing tests


### PR DESCRIPTION
## SpecKit Bundles for Vindicta-Core Features

Adds implementation plans and task lists for **3 feature specifications**:
- `038-domain-validators`: Domain Model Validators
- `039-type-registry`: Shared Type Registry
- `040-event-sourcing`: Event Sourcing Primitives

### Generated By
SpecKit workflow automation