### PR TITLE
Chore: Add markdown link validation pre-commit hooks

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,0 +1,20 @@
+{
+    "ignorePatterns": [
+        {
+            "pattern": "^mailto:"
+        },
+        {
+            "pattern": "^#"
+        }
+    ],
+    "replacementPatterns": [],
+    "httpHeaders": [],
+    "timeout": "5s",
+    "retryOn429": true,
+    "retryCount": 3,
+    "fallbackRetryDelay": "30s",
+    "aliveStatusCodes": [
+        200,
+        206
+    ]
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,9 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
+  - repo: https://github.com/tcort/markdown-link-check
+    rev: v3.12.2
+    hooks:
+      - id: markdown-link-check
+        args: ['--config', '.markdown-link-check.json']
+        types: [markdown]

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -28,6 +28,19 @@ pytest tests/ -v
 3. Write tests first
 4. Submit PR with clear description
 
+## 🔗 Pre-Commit Hooks (Required)
+
+All developers **must** install and run pre-commit hooks before committing. This ensures:
+- All markdown links are validated
+- Code quality standards are enforced
+
+### Setup
+
+```bash
+uv pip install pre-commit
+pre-commit install
+```
+
 ## License
 
 MIT License


### PR DESCRIPTION
Add pre-commit hooks to validate markdown links across the repository. Standardizes documentation quality gates.